### PR TITLE
feat(MSK-93): implement TCF Vendor and Debug APIs

### DIFF
--- a/android/src/main/java/com/axeptiosdk/AxeptioSdkModule.kt
+++ b/android/src/main/java/com/axeptiosdk/AxeptioSdkModule.kt
@@ -141,6 +141,30 @@ class AxeptioSdkModule(reactContext: ReactApplicationContext) :
     promise.resolve(response.toString())
   }
 
+  // MSK-93: Consent Debug Information API
+  @ReactMethod
+  fun getConsentDebugInfo(preferenceKey: String?, promise: Promise) {
+    try {
+      val debugInfo = AxeptioSDK.instance().getConsentDebugInfo(preferenceKey)
+      val writableMap = WritableNativeMap()
+
+      debugInfo.forEach { (key, value) ->
+        when (value) {
+          null -> writableMap.putNull(key)
+          is String -> writableMap.putString(key, value)
+          is Int -> writableMap.putInt(key, value)
+          is Double -> writableMap.putDouble(key, value)
+          is Boolean -> writableMap.putBoolean(key, value)
+          else -> writableMap.putString(key, value.toString())
+        }
+      }
+
+      promise.resolve(writableMap)
+    } catch (e: Exception) {
+      promise.reject("GET_CONSENT_DEBUG_INFO_ERROR", "Failed to get consent debug info: ${e.message}", e)
+    }
+  }
+
   @ReactMethod
   fun addListener(eventName: String?) {
 

--- a/ios/AxeptioSdk.swift
+++ b/ios/AxeptioSdk.swift
@@ -125,6 +125,61 @@ class AxeptioSdk: RCTEventEmitter {
         resolve(result.absoluteString)
     }
 
+    // MARK: - TCF Vendor Consent APIs (MSK-93)
+
+    @objc(getVendorConsents:withRejecter:)
+    func getVendorConsents(
+        resolve: RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        do {
+            let vendorConsents = try Axeptio.shared.getVendorConsents()
+            resolve(vendorConsents)
+        } catch {
+            reject("GET_VENDOR_CONSENTS_ERROR", "Failed to get vendor consents", error)
+        }
+    }
+
+    @objc(getConsentedVendors:withRejecter:)
+    func getConsentedVendors(
+        resolve: RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        do {
+            let consentedVendors = try Axeptio.shared.getConsentedVendors()
+            resolve(consentedVendors)
+        } catch {
+            reject("GET_CONSENTED_VENDORS_ERROR", "Failed to get consented vendors", error)
+        }
+    }
+
+    @objc(getRefusedVendors:withRejecter:)
+    func getRefusedVendors(
+        resolve: RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        do {
+            let refusedVendors = try Axeptio.shared.getRefusedVendors()
+            resolve(refusedVendors)
+        } catch {
+            reject("GET_REFUSED_VENDORS_ERROR", "Failed to get refused vendors", error)
+        }
+    }
+
+    @objc(isVendorConsented:withResolver:withRejecter:)
+    func isVendorConsented(
+        vendorId: String,
+        resolve: RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        do {
+            let isConsented = try Axeptio.shared.isVendorConsented(vendorId: vendorId)
+            resolve(isConsented)
+        } catch {
+            reject("IS_VENDOR_CONSENTED_ERROR", "Failed to check vendor consent for \(vendorId)", error)
+        }
+    }
+
 }
 
 extension GoogleConsentV2 {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -210,6 +210,126 @@ describe('AxeptioSDK', () => {
     });
   });
 
+  describe('TCF Vendor Consent APIs (iOS)', () => {
+    beforeEach(() => {
+      // Ensure we're on iOS for these tests
+      jest.requireMock('react-native').Platform.OS = 'ios';
+    });
+
+    it('should call native getVendorConsents on iOS', async () => {
+      const mockVendorConsents = { '1': true, '2': false };
+      mockAxeptioSdkNative.getVendorConsents = jest
+        .fn()
+        .mockResolvedValue(mockVendorConsents);
+
+      const result = await AxeptioSDK.getVendorConsents();
+
+      expect(result).toEqual(mockVendorConsents);
+      expect(mockAxeptioSdkNative.getVendorConsents).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call native getConsentedVendors on iOS', async () => {
+      const mockConsentedVendors = ['1', '3', '5'];
+      mockAxeptioSdkNative.getConsentedVendors = jest
+        .fn()
+        .mockResolvedValue(mockConsentedVendors);
+
+      const result = await AxeptioSDK.getConsentedVendors();
+
+      expect(result).toEqual(mockConsentedVendors);
+      expect(mockAxeptioSdkNative.getConsentedVendors).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call native getRefusedVendors on iOS', async () => {
+      const mockRefusedVendors = ['2', '4', '6'];
+      mockAxeptioSdkNative.getRefusedVendors = jest
+        .fn()
+        .mockResolvedValue(mockRefusedVendors);
+
+      const result = await AxeptioSDK.getRefusedVendors();
+
+      expect(result).toEqual(mockRefusedVendors);
+      expect(mockAxeptioSdkNative.getRefusedVendors).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call native isVendorConsented on iOS', async () => {
+      const vendorId = '123';
+      mockAxeptioSdkNative.isVendorConsented = jest
+        .fn()
+        .mockResolvedValue(true);
+
+      const result = await AxeptioSDK.isVendorConsented(vendorId);
+
+      expect(result).toBe(true);
+      expect(mockAxeptioSdkNative.isVendorConsented).toHaveBeenCalledWith(
+        vendorId
+      );
+    });
+
+    it('should reject TCF methods on Android', async () => {
+      jest.requireMock('react-native').Platform.OS = 'android';
+
+      await expect(AxeptioSDK.getVendorConsents()).rejects.toThrow(
+        'only available on iOS'
+      );
+      await expect(AxeptioSDK.getConsentedVendors()).rejects.toThrow(
+        'only available on iOS'
+      );
+      await expect(AxeptioSDK.getRefusedVendors()).rejects.toThrow(
+        'only available on iOS'
+      );
+      await expect(AxeptioSDK.isVendorConsented('123')).rejects.toThrow(
+        'only available on iOS'
+      );
+    });
+  });
+
+  describe('Consent Debug Info API (Android)', () => {
+    beforeEach(() => {
+      jest.requireMock('react-native').Platform.OS = 'android';
+    });
+
+    it('should call native getConsentDebugInfo on Android', async () => {
+      const mockDebugInfo = {
+        preference_key_1: 'value1',
+        preference_key_2: 'value2',
+      };
+      mockAxeptioSdkNative.getConsentDebugInfo = jest
+        .fn()
+        .mockResolvedValue(mockDebugInfo);
+
+      const result = await AxeptioSDK.getConsentDebugInfo();
+
+      expect(result).toEqual(mockDebugInfo);
+      expect(mockAxeptioSdkNative.getConsentDebugInfo).toHaveBeenCalledWith(
+        null
+      );
+    });
+
+    it('should call native getConsentDebugInfo with specific key on Android', async () => {
+      const preferenceKey = 'specific_key';
+      const mockDebugInfo = { specific_key: 'specific_value' };
+      mockAxeptioSdkNative.getConsentDebugInfo = jest
+        .fn()
+        .mockResolvedValue(mockDebugInfo);
+
+      const result = await AxeptioSDK.getConsentDebugInfo(preferenceKey);
+
+      expect(result).toEqual(mockDebugInfo);
+      expect(mockAxeptioSdkNative.getConsentDebugInfo).toHaveBeenCalledWith(
+        preferenceKey
+      );
+    });
+
+    it('should reject getConsentDebugInfo on iOS', async () => {
+      jest.requireMock('react-native').Platform.OS = 'ios';
+
+      await expect(AxeptioSDK.getConsentDebugInfo()).rejects.toThrow(
+        'only available on Android'
+      );
+    });
+  });
+
   describe('Error Handling', () => {
     it('should handle native method errors gracefully', async () => {
       const error = new Error('Native method failed');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,6 +85,84 @@ class AxeptioSdk {
     return AxeptioSdkNative.appendAxeptioTokenURL(url, token);
   }
 
+  // MSK-93: TCF Vendor Consent APIs (iOS only)
+
+  /**
+   * Get all vendor consent data (iOS only)
+   * Returns vendor consent information for TCF compliance
+   * @platform iOS
+   * @returns Promise resolving to vendor consents object
+   */
+  getVendorConsents(): Promise<Record<string, any>> {
+    if (Platform.OS !== 'ios') {
+      return Promise.reject(
+        new Error('getVendorConsents is only available on iOS')
+      );
+    }
+    return AxeptioSdkNative.getVendorConsents();
+  }
+
+  /**
+   * Get list of consented vendor IDs (iOS only)
+   * @platform iOS
+   * @returns Promise resolving to array of consented vendor IDs
+   */
+  getConsentedVendors(): Promise<string[]> {
+    if (Platform.OS !== 'ios') {
+      return Promise.reject(
+        new Error('getConsentedVendors is only available on iOS')
+      );
+    }
+    return AxeptioSdkNative.getConsentedVendors();
+  }
+
+  /**
+   * Get list of refused vendor IDs (iOS only)
+   * @platform iOS
+   * @returns Promise resolving to array of refused vendor IDs
+   */
+  getRefusedVendors(): Promise<string[]> {
+    if (Platform.OS !== 'ios') {
+      return Promise.reject(
+        new Error('getRefusedVendors is only available on iOS')
+      );
+    }
+    return AxeptioSdkNative.getRefusedVendors();
+  }
+
+  /**
+   * Check if a specific vendor has been consented to (iOS only)
+   * @platform iOS
+   * @param vendorId - The vendor ID to check
+   * @returns Promise resolving to true if vendor is consented, false otherwise
+   */
+  isVendorConsented(vendorId: string): Promise<boolean> {
+    if (Platform.OS !== 'ios') {
+      return Promise.reject(
+        new Error('isVendorConsented is only available on iOS')
+      );
+    }
+    return AxeptioSdkNative.isVendorConsented(vendorId);
+  }
+
+  // MSK-93: Consent Debug Information API (Android only)
+
+  /**
+   * Get comprehensive consent debug information (Android only)
+   * Combines SharedPreferences and consent file data for troubleshooting
+   * @platform Android
+   * @param preferenceKey - Optional specific preference key to query, or null for all data
+   * @returns Promise resolving to debug information map
+   */
+  getConsentDebugInfo(preferenceKey?: string): Promise<Record<string, any>> {
+    if (Platform.OS !== 'android') {
+      return Promise.reject(
+        new Error('getConsentDebugInfo is only available on Android')
+      );
+    }
+    return AxeptioSdkNative.getConsentDebugInfo(preferenceKey ?? null);
+  }
+
   // SUP-277: iOS WebView synchronization methods
 
   /**


### PR DESCRIPTION
## MSK-93: TCF Vendor and Debug APIs Implementation

Closes https://linear.app/axeptio/issue/MSK-93

### What's implemented

#### iOS TCF Vendor Consent APIs ✅
- `getVendorConsents()` - Get all vendor consent data
- `getConsentedVendors()` - Get list of consented vendors  
- `getRefusedVendors()` - Get list of refused vendors
- `isVendorConsented(vendorId)` - Check specific vendor consent

#### Android Debug Information API ✅
- `getConsentDebugInfo(preferenceKey?)` - Get comprehensive consent debug data

### Features
- ✅ Platform-specific APIs with proper error handling
- ✅ TypeScript definitions with JSDoc comments
- ✅ Comprehensive test coverage: **95.76%** (↑ from 95.14%)
- ✅ 8 new tests for platform-specific behavior (97 total tests)
- ✅ Backward compatible (no breaking changes)

### Test Results
```
Test Suites: 5 passed, 5 total
Tests:       1 skipped, 97 passed, 98 total
Coverage:    95.76% statements, 94.73% branches, 91.83% functions, 95.72% lines
```

### Technical Details
- iOS methods wrapped with try-catch for proper error handling
- Android debug info supports flexible type conversion
- Platform checks prevent calling iOS-only methods on Android and vice versa
- All methods return Promises for async consistency

### Documentation
- JSDoc comments on all new methods
- Platform annotations (@platform iOS/Android)
- Clear error messages for unsupported platforms

---

**Ready for review** ✅

Requires native SDK versions:
- iOS SDK ≥ 2.1.4
- Android SDK ≥ 2.1.2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iOS TCF vendor consent APIs and an Android consent debug API to the React Native SDK to match native 2.1.x capabilities. Supports MSK-93 and keeps the API backward compatible.

- **New Features**
  - iOS: getVendorConsents, getConsentedVendors, getRefusedVendors, isVendorConsented (promise-based with error handling).
  - Android: getConsentDebugInfo(preferenceKey?) returns a typed map for troubleshooting.
  - Platform guards reject unsupported calls; TypeScript definitions with JSDoc included.
  - Tests: +8 new platform-specific tests; coverage at 95.76%.

- **Migration**
  - Requires native SDKs: iOS ≥ 2.1.4, Android ≥ 2.1.2.
  - No breaking changes; existing integrations continue to work.

<sup>Written for commit 45ea0101361405324ab7a1fc5e19d5c99908e06c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

