### PR TITLE
fix: export the full iOS bridge method surface and wire onError

### DIFF
--- a/example-expo/src/App.tsx
+++ b/example-expo/src/App.tsx
@@ -66,6 +66,7 @@ export default function App() {
       const listener: AxeptioEventListener = {
         onPopupClosedEvent: () => {
           // The CMP notice is being hidden
+          console.log('Event: onPopupClosedEvent');
           loadAd();
         },
         onConsentCleared: () => {
@@ -75,7 +76,7 @@ export default function App() {
         },
         onGoogleConsentModeUpdate: (_consents) => {
           // The Google Consent V2 status
-          // Do something
+          console.log('Event: onGoogleConsentModeUpdate', _consents);
         },
       };
       AxeptioSDK.addListener(listener);

--- a/ios/AxeptioSdk.mm
+++ b/ios/AxeptioSdk.mm
@@ -36,6 +36,22 @@ RCT_EXTERN_METHOD(appendAxeptioTokenURL:(NSString)url
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getConsentStatus:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getVendorConsents:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getConsentedVendors:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getRefusedVendors:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(isVendorConsented:(NSString)vendorId
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/ios/AxeptioSdk.swift
+++ b/ios/AxeptioSdk.swift
@@ -23,6 +23,11 @@ class AxeptioSdk: RCTEventEmitter {
             self.sendEvent(withName: "onGoogleConsentModeUpdate", body: consents.toJSObject())
         }
 
+        axeptioEventListener.onError = { [weak self] message in
+            guard let self else { return }
+            self.sendEvent(withName: "onError", body: message)
+        }
+
         Axeptio.shared.setEventListener(axeptioEventListener)
     }
 
@@ -35,6 +40,7 @@ class AxeptioSdk: RCTEventEmitter {
             "onPopupClosedEvent",
             "onConsentCleared",
             "onGoogleConsentModeUpdate",
+            "onError",
         ]
     }
 
@@ -70,6 +76,10 @@ class AxeptioSdk: RCTEventEmitter {
             Axeptio.shared.configure(token: token)
         }
         Axeptio.shared.initialize(targetService: targetService, clientId: clientId, cookiesVersion: cookiesVersion, widgetType: .production)
+        // initialize() resets the SDK's listener state, so the registration done
+        // in init() is lost if it ran first — re-register (official sample sets
+        // the listener only after initialize).
+        Axeptio.shared.setEventListener(axeptioEventListener)
         resolve(nil)
     }
 


### PR DESCRIPTION
## Summary

Found by runtime smoke testing on the simulator before cutting 2.4.0-beta.1 (MSK-246). Two more members of the same family as #90's finds — iOS-only breaks that nothing ever executed:

- **`AxeptioSdk.mm` never exported the MSK-93 API surface**: `getConsentStatus`, `getVendorConsents`, `getConsentedVendors`, `getRefusedVendors`, `isVendorConsented` exist in Swift and JS but had no `RCT_EXTERN_METHOD` declaration — every call threw `undefined is not a function` on iOS. (Android was fine: `@ReactMethod` is the export mechanism there.)
- **`onError` was never wired on iOS**: the 2.2.0 work exposed it in JS and Android but didn't add it to `supportedEvents()` or the listener — every app launch red-boxed `onError is not a supported event type` in dev.
- The SDK event listener is now **re-registered after `initialize()`**, matching the official sample app's ordering.
- Example app now logs the consent events so they're observable during manual testing.

## Verified on simulator (iPhone 16 Pro, iOS 18.6, native SDK 2.4.0)

- `getConsentStatus` resolves over the bridge (alert + log render)
- Launch is clean — no LogBox
- Full consent flow: auto-present on first launch → accept → persists across relaunch (silent restore, `AXEPTIO_CMP_DECISION outcome=skipped_valid_consent`) → clear → re-present → accept

## Known issue (separate ticket)

RN event callbacks (`onPopupClosedEvent`, `onConsentCleared`, `onGoogleConsentModeUpdate`) still don't reach JS on iOS under RN 0.86's bridgeless new arch: the native SDK fires its listener (verified via trace), `sendEvent(withName:)` executes, no React diagnostics are emitted, and nothing arrives in JS. Pre-existing (identical on 2.2.0 — this path was never executed before) and tracked separately; suspect the legacy `RCTEventEmitter` interop path.

Linear: MSK-246

🤖 Generated with [Claude Code](https://claude.com/claude-code)