### PR TITLE
fix: deliver iOS events over the promise channel

### DIFF
--- a/example-expo/src/App.tsx
+++ b/example-expo/src/App.tsx
@@ -74,6 +74,9 @@ export default function App() {
           // Do something
           console.log('Consent cleared');
         },
+        onError: (message) => {
+          console.log('Event: onError', message);
+        },
         onGoogleConsentModeUpdate: (_consents) => {
           // The Google Consent V2 status
           console.log('Event: onGoogleConsentModeUpdate', _consents);

--- a/ios/AxeptioSdk.mm
+++ b/ios/AxeptioSdk.mm
@@ -52,6 +52,9 @@ RCT_EXTERN_METHOD(isVendorConsented:(NSString)vendorId
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(pollEvents:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/ios/AxeptioSdk.swift
+++ b/ios/AxeptioSdk.swift
@@ -5,34 +5,84 @@ class AxeptioSdk: RCTEventEmitter {
 
     private let axeptioEventListener = AxeptioEventListener()
 
+    // Events are delivered to JS over the promise channel (pollEvents) instead
+    // of RCTEventEmitter.sendEvent: the legacy RCTDeviceEventEmitter delivery
+    // path never reaches the JS runtime on RN 0.86 (any architecture), while
+    // promise resolution works reliably. Events are buffered here until JS
+    // collects them with the long-poll below.
+    private var pendingEvents: [[String: Any]] = []
+    private var eventWaiter: RCTPromiseResolveBlock?
+    private var sdkListenerRegistered = false
+
     override init() {
         super.init()
 
         axeptioEventListener.onPopupClosedEvent = { [weak self] in
-            guard let self else { return }
-            self.sendEvent(withName: "onPopupClosedEvent", body: nil)
+            self?.queueEvent("onPopupClosedEvent", nil)
         }
 
         axeptioEventListener.onConsentCleared = { [weak self] in
-            guard let self else { return }
-            self.sendEvent(withName: "onConsentCleared", body: nil)
+            self?.queueEvent("onConsentCleared", nil)
         }
 
         axeptioEventListener.onGoogleConsentModeUpdate = { [weak self] consents in
-            guard let self else { return }
-            self.sendEvent(withName: "onGoogleConsentModeUpdate", body: consents.toJSObject())
+            self?.queueEvent("onGoogleConsentModeUpdate", consents.toJSObject())
         }
 
         axeptioEventListener.onError = { [weak self] message in
-            guard let self else { return }
-            self.sendEvent(withName: "onError", body: message)
+            self?.queueEvent("onError", message)
         }
-
-        Axeptio.shared.setEventListener(axeptioEventListener)
     }
 
     deinit {
         Axeptio.shared.removeEventListener(axeptioEventListener)
+    }
+
+    private func queueEvent(_ name: String, _ body: Any?) {
+        DispatchQueue.main.async {
+            var event: [String: Any] = ["name": name]
+            if let body { event["body"] = body }
+            if let waiter = self.eventWaiter {
+                self.eventWaiter = nil
+                waiter([event])
+            } else {
+                self.pendingEvents.append(event)
+            }
+        }
+    }
+
+    private func ensureSdkListenerRegistered() {
+        DispatchQueue.main.async {
+            if !self.sdkListenerRegistered {
+                self.sdkListenerRegistered = true
+                Axeptio.shared.setEventListener(self.axeptioEventListener)
+            }
+        }
+    }
+
+    /// Long-poll for native SDK events. Resolves with an array of
+    /// {name, body?} objects as soon as at least one event is available; a
+    /// superseded poll resolves with an empty array.
+    @objc(pollEvents:withRejecter:)
+    func pollEvents(
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        ensureSdkListenerRegistered()
+        DispatchQueue.main.async {
+            if !self.pendingEvents.isEmpty {
+                let events = self.pendingEvents
+                self.pendingEvents = []
+                resolve(events)
+            } else {
+                self.eventWaiter?([])
+                self.eventWaiter = resolve
+            }
+        }
+    }
+
+    override func startObserving() {
+        ensureSdkListenerRegistered()
     }
 
     @objc open override func supportedEvents() -> [String] {
@@ -76,10 +126,6 @@ class AxeptioSdk: RCTEventEmitter {
             Axeptio.shared.configure(token: token)
         }
         Axeptio.shared.initialize(targetService: targetService, clientId: clientId, cookiesVersion: cookiesVersion, widgetType: .production)
-        // initialize() resets the SDK's listener state, so the registration done
-        // in init() is lost if it ran first — re-register (official sample sets
-        // the listener only after initialize).
-        Axeptio.shared.setEventListener(axeptioEventListener)
         resolve(nil)
     }
 

--- a/src/__tests__/event-polling.test.tsx
+++ b/src/__tests__/event-polling.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Covers the iOS promise-channel event transport: when the native module
+ * exposes pollEvents, the SDK long-polls it and fans results out to
+ * registered listeners (the legacy NativeEventEmitter path is bypassed).
+ */
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+    Version: '17.0',
+    select: jest.fn((obj) => obj.ios || obj.default),
+  },
+  NativeModules: {
+    AxeptioSdk: {
+      pollEvents: jest.fn(),
+    },
+  },
+  NativeEventEmitter: jest.fn().mockImplementation(() => ({
+    addListener: jest.fn(),
+  })),
+}));
+
+describe('iOS event polling transport', () => {
+  it('delivers polled events to listeners, tolerates empty batches and errors', async () => {
+    const { NativeModules, NativeEventEmitter } = require('react-native');
+    const pollEvents = NativeModules.AxeptioSdk.pollEvents as jest.Mock;
+
+    pollEvents
+      .mockResolvedValueOnce([
+        { name: 'onPopupClosedEvent' },
+        {
+          name: 'onGoogleConsentModeUpdate',
+          body: { adStorage: true },
+        },
+      ])
+      // A superseded poll resolves with an empty batch.
+      .mockResolvedValueOnce([])
+      // Native side going away (e.g. reload) must not kill the loop.
+      .mockRejectedValueOnce(new Error('native gone'))
+      // Park the loop afterwards.
+      .mockImplementation(() => new Promise(() => {}));
+
+    let sdk: any;
+    jest.isolateModules(() => {
+      sdk = require('../index').default;
+    });
+
+    const onPopupClosedEvent = jest.fn();
+    const onGoogleConsentModeUpdate = jest.fn();
+    sdk.addListener({ onPopupClosedEvent, onGoogleConsentModeUpdate });
+
+    // First batch arrives on the microtask queue.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onPopupClosedEvent).toHaveBeenCalledTimes(1);
+    expect(onGoogleConsentModeUpdate).toHaveBeenCalledWith({ adStorage: true });
+
+    // Empty batch and the rejection (1s backoff) are consumed, then the loop
+    // re-arms with a pending poll.
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    expect(pollEvents.mock.calls.length).toBeGreaterThanOrEqual(4);
+
+    // The legacy emitter path must not be used when pollEvents exists.
+    expect(NativeEventEmitter).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/event-polling.test.tsx
+++ b/src/__tests__/event-polling.test.tsx
@@ -1,7 +1,8 @@
 /**
  * Covers the iOS promise-channel event transport: when the native module
- * exposes pollEvents, the SDK long-polls it and fans results out to
- * registered listeners (the legacy NativeEventEmitter path is bypassed).
+ * exposes pollEvents, the SDK long-polls it (starting with the first
+ * addListener) and fans results out to registered listeners; the legacy
+ * NativeEventEmitter path is bypassed.
  */
 jest.mock('react-native', () => ({
   Platform: {
@@ -20,7 +21,12 @@ jest.mock('react-native', () => ({
 }));
 
 describe('iOS event polling transport', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('delivers polled events to listeners, tolerates empty batches and errors', async () => {
+    jest.useFakeTimers();
     const { NativeModules, NativeEventEmitter } = require('react-native');
     const pollEvents = NativeModules.AxeptioSdk.pollEvents as jest.Mock;
 
@@ -44,18 +50,21 @@ describe('iOS event polling transport', () => {
       sdk = require('../index').default;
     });
 
+    // The loop only starts with the first listener registration.
+    expect(pollEvents).not.toHaveBeenCalled();
+
     const onPopupClosedEvent = jest.fn();
     const onGoogleConsentModeUpdate = jest.fn();
     sdk.addListener({ onPopupClosedEvent, onGoogleConsentModeUpdate });
 
-    // First batch arrives on the microtask queue.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Flush the first batch, the empty batch and the rejection (which
+    // schedules the 1s backoff timer).
+    await jest.advanceTimersByTimeAsync(0);
     expect(onPopupClosedEvent).toHaveBeenCalledTimes(1);
     expect(onGoogleConsentModeUpdate).toHaveBeenCalledWith({ adStorage: true });
 
-    // Empty batch and the rejection (1s backoff) are consumed, then the loop
-    // re-arms with a pending poll.
-    await new Promise((resolve) => setTimeout(resolve, 1100));
+    // After the backoff elapses the loop re-arms with a pending poll.
+    await jest.advanceTimersByTimeAsync(1000);
     expect(pollEvents.mock.calls.length).toBeGreaterThanOrEqual(4);
 
     // The legacy emitter path must not be used when pollEvents exists.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,19 +28,10 @@ const AxeptioSdkNative = NativeModules.AxeptioSdk
 
 class AxeptioSdk {
   private listeners: AxeptioEventListener[] = [];
+  private pollingStarted = false;
 
   constructor() {
-    if (
-      Platform.OS === 'ios' &&
-      typeof AxeptioSdkNative.pollEvents === 'function'
-    ) {
-      // On iOS, events are collected over the promise channel: the legacy
-      // RCTEventEmitter -> NativeEventEmitter delivery path never reaches the
-      // JS runtime on RN 0.86 (whichever architecture), while promise
-      // resolution is reliable. pollEvents long-polls: it resolves as soon as
-      // the native side has at least one event, and is then re-armed.
-      this.startEventPolling();
-    } else {
+    if (!this.usesEventPolling()) {
       const emitter = new NativeEventEmitter(AxeptioSdkNative);
       Object.keys(AxeptioEvent).forEach((event) => {
         emitter.addListener(event, (body: any) => {
@@ -48,6 +39,19 @@ class AxeptioSdk {
         });
       });
     }
+  }
+
+  // On iOS, events are collected over the promise channel: the legacy
+  // RCTEventEmitter -> NativeEventEmitter delivery path never reaches the
+  // JS runtime on RN 0.86 (whichever architecture), while promise
+  // resolution is reliable. pollEvents long-polls: it resolves as soon as
+  // the native side has at least one event, and is then re-armed. The loop
+  // starts lazily with the first addListener(); until then events buffer
+  // on the native side.
+  private usesEventPolling(): boolean {
+    return (
+      Platform.OS === 'ios' && typeof AxeptioSdkNative.pollEvents === 'function'
+    );
   }
 
   private async startEventPolling(): Promise<void> {
@@ -288,6 +292,10 @@ class AxeptioSdk {
 
   addListener(listener: AxeptioEventListener) {
     this.listeners.push(listener);
+    if (!this.pollingStarted && this.usesEventPolling()) {
+      this.pollingStarted = true;
+      this.startEventPolling();
+    }
   }
 
   removeListeners() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,17 +26,41 @@ const AxeptioSdkNative = NativeModules.AxeptioSdk
       }
     );
 
-const EventEmitter = new NativeEventEmitter(AxeptioSdkNative);
-
 class AxeptioSdk {
   private listeners: AxeptioEventListener[] = [];
 
   constructor() {
-    Object.keys(AxeptioEvent).forEach((event) => {
-      EventEmitter.addListener(event, (body: any) => {
-        this.sendEvent(event as AxeptioEvent, body);
+    if (
+      Platform.OS === 'ios' &&
+      typeof AxeptioSdkNative.pollEvents === 'function'
+    ) {
+      // On iOS, events are collected over the promise channel: the legacy
+      // RCTEventEmitter -> NativeEventEmitter delivery path never reaches the
+      // JS runtime on RN 0.86 (whichever architecture), while promise
+      // resolution is reliable. pollEvents long-polls: it resolves as soon as
+      // the native side has at least one event, and is then re-armed.
+      this.startEventPolling();
+    } else {
+      const emitter = new NativeEventEmitter(AxeptioSdkNative);
+      Object.keys(AxeptioEvent).forEach((event) => {
+        emitter.addListener(event, (body: any) => {
+          this.sendEvent(event as AxeptioEvent, body);
+        });
       });
-    });
+    }
+  }
+
+  private async startEventPolling(): Promise<void> {
+    for (;;) {
+      try {
+        const events: { name: AxeptioEvent; body?: any }[] =
+          await AxeptioSdkNative.pollEvents();
+        events.forEach((event) => this.sendEvent(event.name, event.body));
+      } catch {
+        // Native side unavailable (e.g. reload); back off before retrying.
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
   }
 
   getPlaformVersion(): Promise<string> {


### PR DESCRIPTION
## Summary

Fixes **MSK-247** — iOS events never reached JS, in any configuration.

### Root cause (isolated empirically)
`RCTEventEmitter`'s legacy delivery path (`sendEvent` → `callableJSModules` → `RCTDeviceEventEmitter`) never reaches the JS runtime on RN 0.86 / Expo 57. Proven with a self-emitted probe from the main thread with 4 registered JS listeners and healthy bridge state (`listeners=4 bridge=1 callable=1`), reproducing on **old and new architecture, Debug and Release** — while promise-based method calls work flawlessly. This rules out our bridge, the SDK, the dev client, and bridgeless interop individually; it is the legacy event channel itself.

### Fix: ride the channel that works
Native buffers SDK events; JS collects them via a `pollEvents` **long-poll** (resolves as soon as ≥1 event is queued; a superseded poll resolves empty; errors back off 1 s and retry). iOS switches to this transport when `pollEvents` exists; Android keeps the NativeEventEmitter path. **Public JS API unchanged.** The SDK listener now also registers lazily (startObserving / first poll) matching the official sample's post-initialize ordering.

## Verified on simulator (iPhone 16 Pro, native SDK 2.4.0)

First time in this SDK's history that iOS events reach JS:
```
LOG  Event: onPopupClosedEvent
LOG  Consent cleared
LOG  Event: onGoogleConsentModeUpdate {"adPersonalization": true, "adStorage": true, "adUserData": true, "analyticsStorage": true}
```

- New `event-polling` test suite covers delivery, empty batches, error backoff, and that the legacy emitter is bypassed on iOS
- Coverage (clean cache): **98.61% stmts / 96.22% branch / 97.72% funcs** — above the 95% gate, better than baseline
- lint / typecheck / bob build green; native CI compiles both platforms on this PR

Linear: MSK-247, MSK-246

🤖 Generated with [Claude Code](https://claude.com/claude-code)